### PR TITLE
Passage de apps/climat à apps/micmac

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	},
 	"scripts": {
 		"postinstall": "node source/scripts/postinstall.js",
-		"compile": "URL_PATH=/apps/climat/ NODE_ENV=production yarn run webpack --config source/webpack.prod.js",
+		"compile": "URL_PATH=/apps/micmac/ NODE_ENV=production yarn run webpack --config source/webpack.prod.js",
 		"stats": "webpack --config source/webpack.prod.js --profile --json > stats.json",
 		"eslint-check": "eslint --print-config .eslintrc | eslint-config-prettier-check",
 		"eslint": "LIST=`git diff --cached --name-only --diff-filter=AMR HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",


### PR DESCRIPTION
La décision n'est pas encore complètement arrêtée, mais en attendant on
se fixe sur le nom de l'outil déjà connu "Micmac"