### PR TITLE
Ecran de fin v2, avec le graphique

### DIFF
--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -26,7 +26,7 @@ export const buildEndURL = (analysis) => {
 			(memo, next) =>
 				memo +
 				next.name[0] +
-				(Math.round(next.nodeValue / 100) / 10).toFixed(1),
+				(Math.round(next.nodeValue / 10) / 100).toFixed(2),
 			''
 		)
 

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -57,6 +57,7 @@ export default function PreviousSimulationBanner() {
 					button {
 						margin: 0 0.2rem;
 					}
+					margin: 0.6rem;
 				`}
 			>
 				{arePreviousAnswers ? (
@@ -92,6 +93,7 @@ export default function PreviousSimulationBanner() {
 				button {
 					margin: 0 0.2rem;
 				}
+				margin: 0.6rem;
 			`}
 		>
 			{arePreviousAnswers && (

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -8,12 +8,28 @@ import { T } from 'Components'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
-import { noUserInputSelector } from 'Selectors/analyseSelectors'
+import {
+	noUserInputSelector,
+	analysisWithDefaultsSelector,
+} from 'Selectors/analyseSelectors'
 import emoji from 'react-easy-emoji'
 import { Button } from 'Components/ui/Button'
 import Answers from './conversation/AnswerList'
 import { useLocation, useHistory } from 'react-router-dom'
 import { last } from 'ramda'
+import { extractCategories } from '../sites/publicodes/chart'
+
+export const buildEndURL = (analysis) => {
+	const total = analysis.targets[0].nodeValue,
+		details = 's2t4l5n1f1a4b2',
+		categories = extractCategories(analysis),
+		detailsString = categories.reduce(
+			(memo, next) => memo + next.name[0] + Math.round(next.nodeValue / 1000),
+			''
+		)
+
+	return `/fin?total=${Math.round(total)}&détails=${detailsString}`
+}
 
 export default function PreviousSimulationBanner() {
 	const previousSimulation = useSelector(
@@ -26,6 +42,7 @@ export default function PreviousSimulationBanner() {
 	)
 	const arePreviousAnswers = !!foldedSteps.length
 	const [showAnswerModal, setShowAnswerModal] = useState(false)
+	const analysis = useSelector(analysisWithDefaultsSelector)
 	const history = useHistory()
 	const location = useLocation()
 
@@ -86,7 +103,7 @@ export default function PreviousSimulationBanner() {
 					</Button>
 					<Button
 						className="simple small"
-						onClick={() => history.push('/fin/6666')}
+						onClick={() => history.push(buildEndURL(analysis))}
 					>
 						{emoji('💤 ')}
 						<T>Fin</T>

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -24,7 +24,9 @@ export const buildEndURL = (analysis) => {
 		categories = extractCategories(analysis),
 		detailsString = categories.reduce(
 			(memo, next) =>
-				memo + next.name[0] + Math.round(next.nodeValue / 100) / 10,
+				memo +
+				next.name[0] +
+				(Math.round(next.nodeValue / 100) / 10).toFixed(1),
 			''
 		)
 

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -21,14 +21,14 @@ import { extractCategories } from '../sites/publicodes/chart'
 
 export const buildEndURL = (analysis) => {
 	const total = analysis.targets[0].nodeValue,
-		details = 's2t4l5n1f1a4b2',
 		categories = extractCategories(analysis),
 		detailsString = categories.reduce(
-			(memo, next) => memo + next.name[0] + Math.round(next.nodeValue / 1000),
+			(memo, next) =>
+				memo + next.name[0] + Math.round(next.nodeValue / 100) / 10,
 			''
 		)
 
-	return `/fin?total=${Math.round(total)}&détails=${detailsString}`
+	return `/fin?total=${Math.round(total)}&details=${detailsString}`
 }
 
 export default function PreviousSimulationBanner() {

--- a/source/components/ShareButton.js
+++ b/source/components/ShareButton.js
@@ -35,6 +35,8 @@ const DesktopShareButton = (props) => {
 		// I prefer to not show the the whole text area selected.
 		e.target.focus()
 		setCopySuccess(true)
+		e.preventDefault()
+		return null
 	}
 
 	return (

--- a/source/components/ShareButton.js
+++ b/source/components/ShareButton.js
@@ -25,7 +25,7 @@ export default (props) =>
 	)
 
 const DesktopShareButton = (props) => {
-	const [copySuccess, setCopySuccess] = useState('')
+	const [copySuccess, setCopySuccess] = useState(false)
 	const textAreaRef = useRef(null)
 
 	function copyToClipboard(e) {
@@ -34,7 +34,7 @@ const DesktopShareButton = (props) => {
 		// This is just personal preference.
 		// I prefer to not show the the whole text area selected.
 		e.target.focus()
-		setCopySuccess('Copié !')
+		setCopySuccess(true)
 	}
 
 	return (
@@ -58,30 +58,44 @@ const DesktopShareButton = (props) => {
 					css={`
 						box-shadow: inset 0 1px 2px rgba(27, 31, 35, 0.075);
 						border-radius: 0.3rem;
+						border-top-right-radius: 0;
+						border-bottom-right-radius: 0;
     border: 1px solid var(--color);
     padding: 0.2rem 0.4rem;
     width: 60%;
     margin: 0 0 0.4rem;
     background: #fffffff2;
+	height: 1.6rem;
+	
 }
 					`}
 					readOnly
 					ref={textAreaRef}
 					value={props.url}
 				/>
-			</form>
-			{
-				/* Logical shortcut for only displaying the 
+				{
+					/* Logical shortcut for only displaying the 
           button if the copy command exists */
-				document.queryCommandSupported('copy') && (
-					<div>
-						<button className="ui__ button small" onClick={copyToClipboard}>
-							Copier le lien
-						</button>{' '}
-						{copySuccess}
-					</div>
-				)
-			}
+					document.queryCommandSupported('copy') && (
+						<button
+							css={`
+								border-radius: 0.3rem;
+								border-bottom-left-radius: 0;
+								border-top-left-radius: 0;
+								border: 1px solid var(--color);
+								margin-left: -1px;
+								height: 1.6rem;
+								background: #ffffffb3;
+								box-shadow: 0 1px 0 rgba(27, 31, 35, 0.04),
+									inset 0 1px 0 hsla(0, 0%, 100%, 0.25);
+							`}
+							onClick={copyToClipboard}
+						>
+							{!copySuccess ? 'Copier le lien' : 'Copié'}
+						</button>
+					)
+				}
+			</form>
 		</div>
 	)
 }

--- a/source/components/Simulation.tsx
+++ b/source/components/Simulation.tsx
@@ -35,25 +35,6 @@ export default function Simulation({
 			{(showConversation || firstStepCompleted) && (
 				<>
 					<Animate.fromTop>
-						<div
-							style={{
-								display: 'flex',
-								justifyContent: 'space-between',
-								marginTop: '1.2rem',
-								marginBottom: '0.6rem',
-								alignItems: 'baseline',
-							}}
-						>
-							{progress < 1 && !noProgressMessage ? (
-								<small css="padding: 0.4rem 0">
-									<T k="simulateurs.précision.défaut">
-										Affinez la simulation en répondant aux questions :
-									</T>
-								</small>
-							) : (
-								<span />
-							)}
-						</div>
 						<Conversation
 							customEnd={customEnd}
 							customEndMessages={customEndMessages}

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -112,7 +112,7 @@ class App extends Component {
 							<Route path="/documentation/:name+" component={RulePage} />
 							<Route path="/documentation" component={RulesList} />
 							<Route path="/simulateur/:name+" component={Simulateur} />
-							<Route path="/fin/:score" component={Fin} />
+							<Route path="/fin" component={Fin} />
 							<Route path="/contribuer/:input?" component={Contribution} />
 							<Route path="/à-propos" component={About} />
 							<Route

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -1,7 +1,7 @@
 import Route404 from 'Components/Route404'
 import RulePage from 'Components/RulePage'
 import React, { Component, Suspense } from 'react'
-import { Link, Route, Switch } from 'react-router-dom'
+import { Link, Route, Redirect, Switch } from 'react-router-dom'
 import 'Ui/index.css'
 import Provider from '../../Provider'
 import RulesList from '../mon-entreprise.fr/pages/Documentation/RulesList'
@@ -112,6 +112,8 @@ class App extends Component {
 							<Route path="/documentation/:name+" component={RulePage} />
 							<Route path="/documentation" component={RulesList} />
 							<Route path="/simulateur/:name+" component={Simulateur} />
+							{/* Lien de compatibilité, à retirer par exemple mi-juillet 2020*/}
+							<Route path="/fin/:score" component={Fin} />
 							<Route path="/fin" component={Fin} />
 							<Route path="/contribuer/:input?" component={Contribution} />
 							<Route path="/à-propos" component={About} />

--- a/source/sites/publicodes/Contribution.js
+++ b/source/sites/publicodes/Contribution.js
@@ -46,7 +46,10 @@ export default ({ match }) => {
 			<p>
 				{emoji('➡ ')}Vous connaissez Github ? Dans ce cas, venez contribuer
 				directement sur le projet{' '}
-				<a href="https://github.com/betagouv/ecolab-data/blob/master/CONTRIBUTING.md">
+				<a
+					href="https://github.com/betagouv/ecolab-data/blob/master/CONTRIBUTING.md"
+					target="_blank"
+				>
 					en suivant ce guide
 				</a>
 				.

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useParams } from 'react-router'
+import { useLocation } from 'react-router'
 import emoji from 'react-easy-emoji'
 import tinygradient from 'tinygradient'
 import { animated, useSpring, config } from 'react-spring'
@@ -25,7 +25,8 @@ const getBackgroundColor = (score) =>
 	]
 
 export default ({}) => {
-	const { score } = useParams()
+	const query = new URLSearchParams(useLocation().search),
+		score = query.get('total')
 	const { value } = useSpring({
 		config: { mass: 1, tension: 150, friction: 150, precision: 1000 },
 		value: +score,

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useLocation } from 'react-router'
+import { useLocation, useParams } from 'react-router'
 import emoji from 'react-easy-emoji'
 import tinygradient from 'tinygradient'
 import { animated, useSpring } from 'react-spring'
@@ -27,14 +27,17 @@ const getBackgroundColor = (score) =>
 
 export default ({}) => {
 	const query = new URLSearchParams(useLocation().search),
-		score = query.get('total'),
-		// details=a2.6t2.1s1.3l1.0b0.8f0.2n0.1
-		encodedDetails = query.get('details'),
-		rehydratedDetails = Object.fromEntries(
-			encodedDetails
-				.match(/[a-z][0-9]+\.[0-9][0-9]/g)
-				.map(([category, ...rest]) => [category, 1000 * +rest.join('')])
-		)
+		score = query.get('total') || useParams().score
+
+	// details=a2.6t2.1s1.3l1.0b0.8f0.2n0.1
+	const encodedDetails = query.get('details'),
+		rehydratedDetails =
+			encodedDetails &&
+			Object.fromEntries(
+				encodedDetails
+					.match(/[a-z][0-9]+\.[0-9][0-9]/g)
+					.map(([category, ...rest]) => [category, 1000 * +rest.join('')])
+			)
 	const { value } = useSpring({
 		config: { mass: 1, tension: 150, friction: 150, precision: 1000 },
 		value: +score,

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -68,38 +68,51 @@ const AnimatedDiv = animated(({ score, value }) => {
 					font-size: 110%;
 				`}
 			>
-				<p css="display: flex; align-items: center; justify-content: center">
-					<img src={BallonGES} css="width: 8rem" />
-					<span css="font-weight: bold; font-size: 260%; margin-bottom: .3rem">
-						<span css="width: 3.6rem; text-align: right; display: inline-block">
-							{Math.round(value / 1000)}
-						</span>{' '}
-						tonnes
-					</span>
-				</p>
-				<div
-					css={`
-						background: #ffffff3d;
-						width: 90%;
-						border-radius: 0.6rem;
-						margin: 0 auto;
-						padding-top: 0.6rem;
+				<div css="display: flex; align-items: center; justify-content: center">
+					<img src={BallonGES} css="width: 30%" />
+					<div>
+						<div css="font-weight: bold; font-size: 280%; margin-bottom: .3rem">
+							<span css="width: 3.6rem; text-align: right; display: inline-block">
+								{Math.round(value / 1000)}
+							</span>{' '}
+							tonnes
+						</div>
+						<div
+							css={`
+								background: #ffffff3d;
+								border-radius: 0.6rem;
+								margin: 0 auto;
+								padding: 0.4rem 1rem;
 
-						> p {
-							display: flex;
-							justify-content: space-around;
-						}
-					`}
-				>
-					<p>
-						<span>{emoji('🇫🇷 ')}</span>
-						<span> Moyenne française</span> <span> 11 tonnes</span>
-					</p>
-					<p>
-						<span>{emoji('😇 ')} </span>
-						<span>Objectif neutralité</span>
-						<span>2 tonnes</span>
-					</p>
+								> div {
+									display: flex;
+									justify-content: space-between;
+									flex-wrap: wrap;
+								}
+								strong {
+									font-weight: bold;
+								}
+								> img {
+									margin: 0 0.6rem !important;
+								}
+							`}
+						>
+							<div>
+								<span>
+									{emoji('🇫🇷 ')}
+									moyenne{' '}
+								</span>{' '}
+								<strong> 11 tonnes</strong>
+							</div>
+							<div>
+								<span>
+									{emoji('😇 ')}
+									objectif{' '}
+								</span>
+								<strong>2 tonnes</strong>
+							</div>
+						</div>
+					</div>
 				</div>
 
 				<div css="display: flex; flex-direction: column;">

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -2,13 +2,14 @@ import React from 'react'
 import { useLocation } from 'react-router'
 import emoji from 'react-easy-emoji'
 import tinygradient from 'tinygradient'
-import { animated, useSpring, config } from 'react-spring'
+import { animated, useSpring } from 'react-spring'
 import ShareButton from 'Components/ShareButton'
 import { findContrastedTextColor } from 'Components/utils/colors'
 import { motion } from 'framer-motion'
 
 import BallonGES from './images/ballonGES.svg'
 import SessionBar from 'Components/SessionBar'
+import Chart from './chart'
 
 const gradient = tinygradient([
 		'#78e08f',
@@ -26,17 +27,24 @@ const getBackgroundColor = (score) =>
 
 export default ({}) => {
 	const query = new URLSearchParams(useLocation().search),
-		score = query.get('total')
+		score = query.get('total'),
+		// details=a2.6t2.1s1.3l1.0b0.8f0.2n0.1
+		encodedDetails = query.get('details'),
+		rehydratedDetails = Object.fromEntries(
+			encodedDetails
+				.match(/.{1,4}/g)
+				.map(([category, ...rest]) => [category, 1000 * +rest.join('')])
+		)
 	const { value } = useSpring({
 		config: { mass: 1, tension: 150, friction: 150, precision: 1000 },
 		value: +score,
 		from: { value: 0 },
 	})
 
-	return <AnimatedDiv value={value} score={score} />
+	return <AnimatedDiv value={value} score={score} details={rehydratedDetails} />
 }
 
-const AnimatedDiv = animated(({ score, value }) => {
+const AnimatedDiv = animated(({ score, value, details }) => {
 	const backgroundColor = getBackgroundColor(value).toHexString(),
 		backgroundColor2 = getBackgroundColor(value + 2000).toHexString(),
 		textColor = findContrastedTextColor(backgroundColor, true)
@@ -122,6 +130,7 @@ const AnimatedDiv = animated(({ score, value }) => {
 						</div>
 					</div>
 				</div>
+				<Chart details={details} noText />
 
 				<div css="display: flex; flex-direction: column;">
 					<ShareButton

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -130,7 +130,9 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 						</div>
 					</div>
 				</div>
-				<Chart details={details} noText />
+				<div css="padding: 1rem">
+					<Chart details={details} noText />
+				</div>
 
 				<div css="display: flex; flex-direction: column;">
 					<ShareButton

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -52,7 +52,7 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 	return (
 		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 0 auto;">
 			<SessionBar />
-			<h1 css="margin: 0;font-size: 160%">Mon empreinte climat</h1>
+			<h1 css="margin: 0;font-size: 160%">Mon empreinte</h1>
 			<motion.div
 				animate={{ scale: [0.85, 1] }}
 				transition={{ duration: 0.2, ease: 'easeIn' }}
@@ -67,7 +67,7 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 					color: ${textColor};
 					margin: 0 auto;
 					border-radius: 0.6rem;
-					height: 60vh;
+					height: 65vh;
 					display: flex;
 					flex-direction: column;
 					justify-content: space-evenly;
@@ -77,7 +77,7 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 				`}
 			>
 				<div css="display: flex; align-items: center; justify-content: center">
-					<img src={BallonGES} css="width: 30%" />
+					<img src={BallonGES} css="height: 10rem" />
 					<div>
 						<div css="font-weight: bold; font-size: 280%; margin-bottom: .3rem">
 							<span css="width: 3.6rem; text-align: right; display: inline-block">
@@ -119,7 +119,7 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 								</span>
 								<strong>2 tonnes</strong>
 							</div>
-							<div css="margin-top: .4rem;justify-content: flex-end !important">
+							<div css="margin-top: .2rem;justify-content: flex-end !important">
 								<a
 									css="color: inherit"
 									href="https://ecolab.ademe.fr/blog/général/budget-empreinte-carbone-c-est-quoi.md"

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -131,7 +131,7 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 					</div>
 				</div>
 				<div css="padding: 1rem">
-					<Chart details={details} noText />
+					<Chart details={details} color={textColor} noAnimation noText />
 				</div>
 
 				<div css="display: flex; flex-direction: column;">

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -32,7 +32,7 @@ export default ({}) => {
 		encodedDetails = query.get('details'),
 		rehydratedDetails = Object.fromEntries(
 			encodedDetails
-				.match(/.{1,4}/g)
+				.match(/[a-z][0-9]+\.[0-9][0-9]/g)
 				.map(([category, ...rest]) => [category, 1000 * +rest.join('')])
 		)
 	const { value } = useSpring({

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -111,6 +111,14 @@ const AnimatedDiv = animated(({ score, value }) => {
 								</span>
 								<strong>2 tonnes</strong>
 							</div>
+							<div css="margin-top: .4rem;justify-content: flex-end !important">
+								<a
+									css="color: inherit"
+									href="https://ecolab.ademe.fr/blog/général/budget-empreinte-carbone-c-est-quoi.md"
+								>
+									Comment ça ?
+								</a>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/source/sites/publicodes/Simulateur.js
+++ b/source/sites/publicodes/Simulateur.js
@@ -18,6 +18,7 @@ import Chart from './chart/index.js'
 import { Redirect } from 'react-router'
 import SessionBar from 'Components/SessionBar'
 import { isEmpty, symmetricDifference, compose } from 'ramda'
+import { buildEndURL } from 'Components/SessionBar'
 
 let CarbonImpactWithData = withTarget(CarbonImpact)
 const eqValues = compose(isEmpty, symmetricDifference)
@@ -58,9 +59,7 @@ const Simulateur = (props) => {
 				showConversation
 				customEnd={
 					rule.dottedName === 'bilan' ? (
-						<Redirect
-							to={`/fin/${Math.round(analysis.targets[0].nodeValue)}`}
-						/>
+						<Redirect to={buildEndURL(analysis)} />
 					) : rule.description ? (
 						<Markdown source={rule.description} />
 					) : (

--- a/source/sites/publicodes/chart/Bar.js
+++ b/source/sites/publicodes/chart/Bar.js
@@ -21,14 +21,14 @@ export default ({
 			css={`
 				display: flex;
 				align-items: center;
-				height: 0.85rem;
+				height: 1rem;
 			`}
 		>
 			<span
 				css={`
 					font-size: 140%;
-					width: 2.1rem;
-					margin-left: -2.1rem;
+					width: 2.3rem;
+					margin-left: -2.3rem;
 				`}
 			>
 				{emoji(icônes)}

--- a/source/sites/publicodes/chart/Bar.js
+++ b/source/sites/publicodes/chart/Bar.js
@@ -9,11 +9,14 @@ export default ({
 	icônes = '🌍',
 	title,
 	empreinteMaximum,
+	noText,
 }) => (
 	<>
-		<div css="color: var(--textColorOnWhite)">
-			<span>{title}</span>
-		</div>
+		{!noText && (
+			<div css="color: var(--textColorOnWhite)">
+				<span>{title}</span>
+			</div>
+		)}
 		<div
 			css={`
 				display: flex;

--- a/source/sites/publicodes/chart/Bar.js
+++ b/source/sites/publicodes/chart/Bar.js
@@ -10,6 +10,7 @@ export default ({
 	title,
 	empreinteMaximum,
 	noText,
+	color,
 }) => (
 	<>
 		{!noText && (
@@ -47,7 +48,7 @@ export default ({
 					${shadowStyle}
 				`}
 			></span>
-			<Value {...{ nodeValue }} />
+			<Value {...{ color, nodeValue }} />
 		</div>
 	</>
 )

--- a/source/sites/publicodes/chart/Value.js
+++ b/source/sites/publicodes/chart/Value.js
@@ -9,10 +9,16 @@ const humanWeightUnit = (v) =>
 		? [v, 'kg']
 		: [v / 1000, 't']
 
-export default ({ nodeValue }) => {
+export default ({ nodeValue, color }) => {
 	const [value, unit] = humanWeightUnit(nodeValue)
 	return (
-		<span css="color: var(--textColorOnWhite); font-weight: 600; vertical-align: baseline;">
+		<span
+			css={`
+				color: ${color || 'var(--textColorOnWhite)'};
+				font-weight: 600;
+				vertical-align: baseline;
+			`}
+		>
 			{value < 10 ? value.toFixed(1) : Math.round(value)}&nbsp;{unit}
 		</span>
 	)

--- a/source/sites/publicodes/chart/index.js
+++ b/source/sites/publicodes/chart/index.js
@@ -37,7 +37,8 @@ export default ({ details, color, noText, noAnimation }) => {
 
 	const categories = analysis?.targets.length
 		? extractCategories(analysis)
-		: sortCategories(
+		: details &&
+		  sortCategories(
 				rules['bilan'].formule.explanation.explanation.map((reference) => {
 					const category = rules[reference.dottedName]
 					return {
@@ -46,8 +47,7 @@ export default ({ details, color, noText, noAnimation }) => {
 					}
 				})
 		  )
-
-	console.log(categories[0])
+	if (!categories) return null
 
 	const empreinteMaximum = categories.reduce(
 		(memo, next) => (memo.nodeValue > next.nodeValue ? memo : next),

--- a/source/sites/publicodes/chart/index.js
+++ b/source/sites/publicodes/chart/index.js
@@ -31,7 +31,7 @@ export const extractCategories = (analysis) => {
 
 	return sortCategories(categories)
 }
-export default ({ details, noText }) => {
+export default ({ details, color, noText, noAnimation }) => {
 	const analysis = useSelector(analysisWithDefaultsSelector),
 		rules = useSelector(parsedRulesSelector)
 
@@ -96,11 +96,15 @@ export default ({ details, noText }) => {
 				>
 					{categories.map((category) => (
 						<motion.li
-							layoutTransition={{
-								type: 'spring',
-								damping: 100,
-								stiffness: 100,
-							}}
+							layoutTransition={
+								noAnimation
+									? null
+									: {
+											type: 'spring',
+											damping: 100,
+											stiffness: 100,
+									  }
+							}
 							key={category.title}
 							css={`
 								margin: 0.4rem 0;
@@ -115,7 +119,7 @@ export default ({ details, noText }) => {
 							<Link
 								to={'/documentation/' + encodeRuleName(category.dottedName)}
 							>
-								<Bar {...{ ...category, noText, empreinteMaximum }} />
+								<Bar {...{ ...category, color, noText, empreinteMaximum }} />
 							</Link>
 						</motion.li>
 					))}

--- a/source/sites/publicodes/chart/index.js
+++ b/source/sites/publicodes/chart/index.js
@@ -16,19 +16,22 @@ const // Rough estimate of the 2050 budget per person to stay under 2° by 2100
 	transportShare = 1 / 4,
 	transportClimateBudget = climateBudgetPerDay * transportShare
 
-export default ({}) => {
-	const analysis = useSelector(analysisWithDefaultsSelector)
+export const extractCategories = (analysis) => {
 	const getRule = getRuleFromAnalysis(analysis)
 
 	const bilan = getRule('bilan')
 	if (!bilan) return null
 
-	const categories = sortBy(
+	return sortBy(
 		({ nodeValue }) => -nodeValue,
 		bilan.formule.explanation.explanation.map(
 			(category) => category.explanation
 		)
 	)
+}
+export default ({}) => {
+	const analysis = useSelector(analysisWithDefaultsSelector)
+	const categories = extractCategories(analysis)
 
 	const empreinteMaximum = categories.reduce(
 		(memo, next) => (memo.nodeValue > next.nodeValue ? memo : next),

--- a/source/sites/publicodes/chart/index.js
+++ b/source/sites/publicodes/chart/index.js
@@ -90,7 +90,7 @@ export default ({ details, noText }) => {
 						margin-left: 2rem;
 
 						@media (min-width: 800px) {
-							width: 35rem;
+							max-width: 35rem;
 						}
 					`}
 				>


### PR DESCRIPTION
Pour l'instant je pars sur cet encodage : /fin?total=8097&détails=a3.23t2.12s1.56l1.56b1.12f0.08n0.34

Comme ça le total reste lisible, et les détails sont encodés à la fin de la façon la plus courte possible, sans perdre trop de détail.

![image](https://user-images.githubusercontent.com/1177762/86027296-cf757780-ba30-11ea-8c5b-3c162e28800f.png)

Fixes betagouv/ecolab-data/issues/50
