### PR TITLE
Logo ademe

### DIFF
--- a/source/sites/publicodes/Landing.js
+++ b/source/sites/publicodes/Landing.js
@@ -65,13 +65,12 @@ export default () => {
 				`}
 			>
 				<div>
-					<em>En partenariat avec l'</em>
-					{/* Un jour
-				<img
-					css="height: 3rem"
-					src="https://www.ademe.fr/sites/all/themes/ademe/logo.png"
-				/>
-				*/}
+					<a href="https://ademe.fr">
+						<img
+							css="height: 4rem; margin-right: .6rem"
+							src="https://www.ademe.fr/sites/all/themes/ademe/logo.png"
+						/>
+					</a>
 					<a href="https://www.associationbilancarbone.fr/">
 						<img
 							css="height: 2.5rem"


### PR DESCRIPTION
Pour enlever toute ambiguïté, malgré le nom de domaine en .ademe.fr