### PR TITLE
Changement de l'image de partage pour le dessin

### DIFF
--- a/source/webpack.common.js
+++ b/source/webpack.common.js
@@ -118,9 +118,9 @@ module.exports.HTMLPlugins = ({
 } = {}) => [
 	new HTMLPlugin({
 		template: 'index.html',
-		logo: 'https://ecolab.ademe.fr/apps/climat/nosgestesclimat.png',
+		logo: 'https://ecolab.ademe.fr/apps/climat/images/ecolab-climat-dessin.svg',
 		chunks: ['publicodes'],
-		title: 'Nos gestes climat - Ecolab',
+		title: 'Nos Gestes Climat',
 		description: 'Connaissez-vous votre empreinte sur le climat ?',
 		filename: 'index.html',
 		injectTrackingScript,


### PR DESCRIPTION
> 2ème essai

C'est carré sur twitter, donc le logo Nos Gestes Climat n'est pas
lisible.
Et puis souvent, l'image de partage n'est pas le logo, mais
l'illustration de l'article.
J'ai aussi changé le texte pour mettre des majuscules et enlever "Ecolab"