### PR TITLE
Suivi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "futureco",
+	"name": "nosgestesclimat",
 	"license": "MIT",
 	"version": "1.2.3",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/laem/futureco.git"
+		"url": "https://github.com/betagouv/ecolab-climat.git"
 	},
 	"browserslist": [
 		"> 1% in FR"

--- a/source/Tracker.ts
+++ b/source/Tracker.ts
@@ -1,5 +1,5 @@
 import { History, Location } from 'history'
-import { debounce } from './utils'
+import { debounce, inIframe } from './utils'
 
 declare global {
 	interface Window {
@@ -10,18 +10,35 @@ declare global {
 type PushArgs = ['trackPageView'] | ['trackEvent', ...Array<string | number>]
 type PushType = (args: PushArgs) => void
 
+const ua = window.navigator.userAgent
+// https://chromium.googlesource.com/chromium/src.git/+/master/docs/ios/user_agent.md
+const iOSSafari =
+	(!!/iPad/i.exec(ua) || !!/iPhone/i.exec(ua)) &&
+	!!/WebKit/i.exec(ua) &&
+	!/CriOS/i.exec(ua)
+
 export default class Tracker {
 	push: PushType
 	unlistenFromHistory: (() => void) | undefined
 	previousPath: string | undefined
 
-	constructor(pushFunction: PushType = args => window._paq.push(args)) {
+	constructor(
+		pushFunction: PushType = (args) => {
+			// There is an issue with the way Safari handle cookies in iframe, cf.
+			// https://gist.github.com/iansltx/18caf551baaa60b79206. We could probably
+			// do better but for now we don't track action of iOs Safari user in
+			// iFrame -- to avoid errors in the number of visitors in our stats.
+			if (!(iOSSafari && inIframe)) {
+				window._paq.push(args)
+			}
+		}
+	) {
 		if (typeof window !== 'undefined') window._paq = window._paq || []
 		this.push = debounce(200, pushFunction) as PushType
 	}
 
 	connectToHistory(history: History) {
-		this.unlistenFromHistory = history.listen(loc => {
+		this.unlistenFromHistory = history.listen((loc) => {
 			this.track(loc)
 		})
 

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -71,9 +71,9 @@ export default function Conversation({
 
 	useEffect(() => {
 		if (previousAnswers.length === 1) {
-			tracker.push(['trackEvent', '1ère réponse au bilan'])
+			tracker.push(['trackEvent', 'NGC', '1ère réponse au bilan'])
 		}
-	}, [previousAnswers])
+	}, [previousAnswers, tracker])
 
 	const setDefault = () =>
 		dispatch(

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -3,7 +3,8 @@ import { T } from 'Components'
 import QuickLinks from 'Components/QuickLinks'
 import getInputComponent from 'Engine/getInputComponent'
 import { findRuleByDottedName } from 'Engine/rules'
-import React, { useState } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
+import { TrackerContext } from 'Components/utils/withTracker'
 import emoji from 'react-easy-emoji'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
@@ -65,6 +66,14 @@ export default function Conversation({
 		(state: RootState) => state.conversationSteps.foldedSteps
 	)
 	const nextSteps = useSelector(nextStepsSelector)
+
+	const tracker = useContext(TrackerContext)
+
+	useEffect(() => {
+		if (previousAnswers.length === 1) {
+			tracker.push(['trackEvent', '1ère réponse au bilan'])
+		}
+	}, [previousAnswers])
 
 	const setDefault = () =>
 		dispatch(

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -20,8 +20,14 @@ import {
 	persistSimulation,
 	retrievePersistedSimulation,
 } from '../../storage/persistSimulation'
+import Tracker, { devTracker } from '../../Tracker'
 
 let Studio = React.lazy(() => import('./Studio'))
+
+let tracker = devTracker
+if (process.env.NODE_ENV === 'production') {
+	tracker = new Tracker()
+}
 
 class App extends Component {
 	render() {
@@ -41,6 +47,7 @@ class App extends Component {
 				}ecolab-data.netlify.app/co2.json`}
 				dataBranch={branch || pullRequestNumber}
 				sitePaths={sitePaths()}
+				tracker={tracker}
 				reduxMiddlewares={[]}
 				onStoreCreated={(store) => {
 					//persistEverything({ except: ['rules', 'simulation'] })(store)

--- a/source/sites/publicodes/Simulateur.js
+++ b/source/sites/publicodes/Simulateur.js
@@ -5,7 +5,8 @@ import ShareButton from 'Components/ShareButton'
 import Simulation from 'Components/Simulation'
 import { Markdown } from 'Components/utils/markdown'
 import { decodeRuleName, findRuleByDottedName } from 'Engine/rules'
-import React, { useEffect } from 'react'
+import React, { useEffect, useContext } from 'react'
+import { TrackerContext } from 'Components/utils/withTracker'
 import { Helmet } from 'react-helmet'
 import { useDispatch, useSelector } from 'react-redux'
 import {
@@ -60,7 +61,7 @@ const Simulateur = (props) => {
 				showConversation
 				customEnd={
 					rule.dottedName === 'bilan' ? (
-						<Redirect to={buildEndURL(analysis)} />
+						<RedirectionToEndPage url={buildEndURL(analysis)} />
 					) : rule.description ? (
 						<Markdown source={rule.description} />
 					) : (
@@ -89,5 +90,15 @@ let PeriodBlock = () => (
 		<PeriodSwitch />
 	</div>
 )
+
+const RedirectionToEndPage = ({ url }) => {
+	const tracker = useContext(TrackerContext)
+
+	useEffect(() => {
+		tracker.push(['trackEvent', 'NGC', 'A terminé la simulation'])
+	}, [tracker])
+
+	return <Redirect to={url} />
+}
 
 export default Simulateur

--- a/source/webpack.dev.js
+++ b/source/webpack.dev.js
@@ -22,7 +22,7 @@ module.exports = {
 	mode: 'development',
 	plugins: [
 		...(common.plugins || []),
-		...HTMLPlugins(),
+		...HTMLPlugins({ injectTrackingScript: true }),
 		new ReactRefreshWebpackPlugin(),
 		new webpack.EnvironmentPlugin({ NODE_ENV: 'development' }),
 		new webpack.HotModuleReplacementPlugin(),

--- a/source/webpack.prod.js
+++ b/source/webpack.prod.js
@@ -28,7 +28,10 @@ module.exports = {
 	},
 	plugins: [
 		...(common.plugins || []),
-		...HTMLPlugins({ prodPath: prodPath + '/', injectTrackingScript: true }),
+		...HTMLPlugins({
+			prodPath: prodPath ? prodPath + '/' : null,
+			injectTrackingScript: true,
+		}),
 		new MiniCssExtractPlugin({
 			// Options similar to the same options in webpackOptions.output
 			// both options are optional


### PR DESCRIPTION
Ici on passe à un suivi Matomo en JS, pour avoir le contrôle total des événements qu'on déclenche, et pour suivre chaque page de cette SPA.

Fixes #114 et #113 

☑ Je n'arrive pas à suivre mes visites sur localhost, et il semble que nos branches de déploiement soient cassées 😔 
Je reprends lundi. 