### PR TITLE
Maj lien

### DIFF
--- a/source/sites/publicodes/about.md
+++ b/source/sites/publicodes/about.md
@@ -8,7 +8,7 @@ Il est basé sur le modèle MicMac des associations [Avenir Climatique](https://
 
 ## Qui le développe ?
 
-Il est développé par une équipe de [beta.gouv.fr](https://beta.gouv.fr/), financée par l’[Agence de la transition écologique (ADEME)](https://www.ademe.fr/) en partenariat avec l’[Association Bilan Carbone (ABC)](https://www.associationbilancarbone.fr/).
+Il est développé par une équipe de [beta.gouv.fr](https://beta.gouv.fr/), financée par l’[Agence de la transition écologique](https://www.ademe.fr/) (ADEME) en partenariat avec l’[Association Bilan Carbone](https://www.associationbilancarbone.fr/) (ABC).
 
 Depuis sa création en 2011, l'ABC est partenaire de l’ADEME. Ce partenariat a vu naître de nombreux projets autour du développement et de la promotion des méthodes et outils innovants pour la mise en œuvre de stratégies climat, en France et à l’international, que ce soit à l’échelle des organisations, territoires ou des citoyens.
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46482115/100115905-6117d280-2e73-11eb-9e7a-9f0320a414cf.png)

Les espaces insécables des liens font des retours à la ligne pas idéal. Je propose de retirer les acronymes des liens