### PR TITLE
Fiches elaborees

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -10,7 +10,7 @@ rules:
   react/prop-types: 0
   react/jsx-no-target-blank: 0
   react/no-unescaped-entities: 0
-  react/display-name: 1
+  react/display-name: 0
   react-hooks/rules-of-hooks: error
   react-hooks/exhaustive-deps: warn
 parser: babel-eslint

--- a/source/sites/publicodes/Action.js
+++ b/source/sites/publicodes/Action.js
@@ -1,32 +1,31 @@
-import React, { useEffect, useContext } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { useParams } from 'react-router'
+import React, {useEffect, useContext} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {useParams} from 'react-router'
 import emoji from 'react-easy-emoji'
-import { animated, useSpring, config } from 'react-spring'
+import {animated, useSpring, config} from 'react-spring'
 import ShareButton from 'Components/ShareButton'
-import { findContrastedTextColor } from 'Components/utils/colors'
-import { motion } from 'framer-motion'
+import {findContrastedTextColor} from 'Components/utils/colors'
+import {motion} from 'framer-motion'
 
 import BallonGES from './images/ballonGES.svg'
 import SessionBar from 'Components/SessionBar'
-import { Link } from 'react-router-dom'
-import { humanWeight, HumanWeight } from './HumanWeight'
-import { Markdown } from 'Components/utils/markdown'
-import { encodeRuleName, decodeRuleName, splitName } from 'Engine/rules'
-import { SitePathsContext } from 'Components/utils/withSitePaths'
+import {Link} from 'react-router-dom'
+import {humanWeight, HumanWeight} from './HumanWeight'
+import {Markdown} from 'Components/utils/markdown'
+import {encodeRuleName, decodeRuleName, splitName} from 'Engine/rules'
+import {SitePathsContext} from 'Components/utils/withSitePaths'
 import {
 	flatRulesSelector,
 	analysisWithDefaultsSelector,
 	nextStepsSelector,
 } from 'Selectors/analyseSelectors'
-import { setSimulationConfig } from 'Actions/actions'
+import {setSimulationConfig} from 'Actions/actions'
 import Simulation from 'Components/Simulation'
 
-export const Footprint = ({ value }) => <div>Lala {value}</div>
+export const Footprint = ({value}) => <div>Lala {value}</div>
 
 export default ({}) => {
-	const { encodedName } = useParams()
-	console.log('ECN', encodedName)
+	const {encodedName} = useParams()
 	const sitePaths = useContext(SitePathsContext)
 	const rules = useSelector(flatRulesSelector)
 	const nextSteps = useSelector(nextStepsSelector)
@@ -43,7 +42,7 @@ export default ({}) => {
 	useEffect(() => dispatch(setSimulationConfig(config)), [encodedName])
 	if (!configSet) return null
 
-	const { nodeValue, description, icons, title } = analysis.targets[0]
+	const {nodeValue, description, icons, title} = analysis.targets[0]
 
 	const flatActions = rules.find((r) => r.dottedName === 'actions')
 	const relatedActions = flatActions.formule.somme
@@ -52,7 +51,7 @@ export default ({}) => {
 				actionDottedName !== dottedName &&
 				splitName(dottedName)[0] === splitName(actionDottedName)[0]
 		)
-		.map((name) => rules.find(({ dottedName }) => dottedName === name))
+		.map((name) => rules.find(({dottedName}) => dottedName === name))
 
 	return (
 		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 1rem auto;">
@@ -93,6 +92,9 @@ export default ({}) => {
 							</button>
 						)
 					}
+					<Link to={`/actions/plus/` + encodedName}><button className="ui__ button plain">
+						En savoir plus
+					</button></Link>
 				</div>
 			</div>
 			<SessionBar answerButtonOnly />

--- a/source/sites/publicodes/Action.js
+++ b/source/sites/publicodes/Action.js
@@ -1,31 +1,31 @@
-import React, {useEffect, useContext} from 'react'
-import {useDispatch, useSelector} from 'react-redux'
-import {useParams} from 'react-router'
+import React, { useEffect, useContext } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useParams } from 'react-router'
 import emoji from 'react-easy-emoji'
-import {animated, useSpring, config} from 'react-spring'
+import { animated, useSpring, config } from 'react-spring'
 import ShareButton from 'Components/ShareButton'
-import {findContrastedTextColor} from 'Components/utils/colors'
-import {motion} from 'framer-motion'
+import { findContrastedTextColor } from 'Components/utils/colors'
+import { motion } from 'framer-motion'
 
 import BallonGES from './images/ballonGES.svg'
 import SessionBar from 'Components/SessionBar'
-import {Link} from 'react-router-dom'
-import {humanWeight, HumanWeight} from './HumanWeight'
-import {Markdown} from 'Components/utils/markdown'
-import {encodeRuleName, decodeRuleName, splitName} from 'Engine/rules'
-import {SitePathsContext} from 'Components/utils/withSitePaths'
+import { Link } from 'react-router-dom'
+import { humanWeight, HumanWeight } from './HumanWeight'
+import { Markdown } from 'Components/utils/markdown'
+import { encodeRuleName, decodeRuleName, splitName } from 'Engine/rules'
+import { SitePathsContext } from 'Components/utils/withSitePaths'
 import {
 	flatRulesSelector,
 	analysisWithDefaultsSelector,
 	nextStepsSelector,
 } from 'Selectors/analyseSelectors'
-import {setSimulationConfig} from 'Actions/actions'
+import { setSimulationConfig } from 'Actions/actions'
 import Simulation from 'Components/Simulation'
 
-export const Footprint = ({value}) => <div>Lala {value}</div>
+export const Footprint = ({ value }) => <div>Lala {value}</div>
 
 export default ({}) => {
-	const {encodedName} = useParams()
+	const { encodedName } = useParams()
 	const sitePaths = useContext(SitePathsContext)
 	const rules = useSelector(flatRulesSelector)
 	const nextSteps = useSelector(nextStepsSelector)
@@ -42,7 +42,7 @@ export default ({}) => {
 	useEffect(() => dispatch(setSimulationConfig(config)), [encodedName])
 	if (!configSet) return null
 
-	const {nodeValue, description, icons, title} = analysis.targets[0]
+	const { nodeValue, description, icons, title, plus } = analysis.targets[0]
 
 	const flatActions = rules.find((r) => r.dottedName === 'actions')
 	const relatedActions = flatActions.formule.somme
@@ -51,7 +51,7 @@ export default ({}) => {
 				actionDottedName !== dottedName &&
 				splitName(dottedName)[0] === splitName(actionDottedName)[0]
 		)
-		.map((name) => rules.find(({dottedName}) => dottedName === name))
+		.map((name) => rules.find(({ dottedName }) => dottedName === name))
 
 	return (
 		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 1rem auto;">
@@ -84,17 +84,11 @@ export default ({}) => {
 				</header>
 				<div css="margin: 1.6rem 0">
 					<Markdown source={description} />
-					{
-						// Nous n'avons pas encore intégré cette fonctionnalités, qui affichera le markdown de l'attribut "en savvoir plus"
-						false && (
-							<button className="ui__ button simple small">
-								En savoir plus
-							</button>
-						)
-					}
-					<Link to={`/actions/plus/` + encodedName}><button className="ui__ button plain">
-						En savoir plus
-					</button></Link>
+					{plus && (
+						<Link to={'/actions/plus/' + encodedName}>
+							<button className="ui__ button plain">En savoir plus</button>
+						</Link>
+					)}
 				</div>
 			</div>
 			<SessionBar answerButtonOnly />

--- a/source/sites/publicodes/ActionPlus.js
+++ b/source/sites/publicodes/ActionPlus.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import {Markdown} from 'Components/utils/markdown'
+import {useParams} from 'react-router'
+import {flatRulesSelector} from 'Selectors/analyseSelectors'
+import {useSelector} from 'react-redux'
+import {findRuleByDottedName} from 'Engine/rules'
+
+
+export default () => {
+
+	const {encodedName} = useParams()
+	const rules = useSelector(flatRulesSelector)
+	console.log(rules)
+	const rule = findRuleByDottedName(rules, 'transport . éco-conduite')
+
+	if (!rule) return <div>OUPS</div>
+
+
+	return (
+
+		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 1rem auto;">
+			<h1>{rule.title}</h1>
+			<div css="margin: 1.6rem 0">
+				<Markdown source={rule.description} />
+			</div>
+
+		</div>
+	)
+}

--- a/source/sites/publicodes/ActionPlus.js
+++ b/source/sites/publicodes/ActionPlus.js
@@ -18,7 +18,7 @@ export default () => {
 		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 1rem auto;">
 			<div css="margin: 1.6rem 0">
 				<Markdown
-					source={rule.plus || "Cette fiche détaillées n'existe pas encore"}
+					source={rule.plus || "Cette fiche détaillée n'existe pas encore"}
 				/>
 			</div>
 		</div>

--- a/source/sites/publicodes/ActionPlus.js
+++ b/source/sites/publicodes/ActionPlus.js
@@ -4,6 +4,8 @@ import { useParams } from 'react-router'
 import { flatRulesSelector } from 'Selectors/analyseSelectors'
 import { useSelector } from 'react-redux'
 import { findRuleByDottedName, decodeRuleName } from 'Engine/rules'
+import { Link } from 'react-router-dom'
+import emoji from 'react-easy-emoji'
 
 export default () => {
 	const { encodedName } = useParams()
@@ -16,6 +18,11 @@ export default () => {
 
 	return (
 		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 1rem auto;">
+			<Link to={'/actions/' + encodedName}>
+				<button className="ui__ button simple small ">
+					{emoji('◀')} Retour
+				</button>
+			</Link>
 			<div css="margin: 1.6rem 0">
 				<Markdown
 					source={rule.plus || "Cette fiche détaillée n'existe pas encore"}

--- a/source/sites/publicodes/ActionPlus.js
+++ b/source/sites/publicodes/ActionPlus.js
@@ -1,29 +1,26 @@
 import React from 'react'
-import {Markdown} from 'Components/utils/markdown'
-import {useParams} from 'react-router'
-import {flatRulesSelector} from 'Selectors/analyseSelectors'
-import {useSelector} from 'react-redux'
-import {findRuleByDottedName} from 'Engine/rules'
-
+import { Markdown } from 'Components/utils/markdown'
+import { useParams } from 'react-router'
+import { flatRulesSelector } from 'Selectors/analyseSelectors'
+import { useSelector } from 'react-redux'
+import { findRuleByDottedName, decodeRuleName } from 'Engine/rules'
 
 export default () => {
-
-	const {encodedName} = useParams()
+	const { encodedName } = useParams()
 	const rules = useSelector(flatRulesSelector)
-	console.log(rules)
-	const rule = findRuleByDottedName(rules, 'transport . éco-conduite')
+	const dottedName = decodeRuleName(encodedName)
+	const rule = findRuleByDottedName(rules, dottedName)
 
+	console.log(rule)
 	if (!rule) return <div>OUPS</div>
 
-
 	return (
-
 		<div css="padding: 0 .3rem 1rem; max-width: 600px; margin: 1rem auto;">
-			<h1>{rule.title}</h1>
 			<div css="margin: 1.6rem 0">
-				<Markdown source={rule.description} />
+				<Markdown
+					source={rule.plus || "Cette fiche détaillées n'existe pas encore"}
+				/>
 			</div>
-
 		</div>
 	)
 }

--- a/source/sites/publicodes/Actions.js
+++ b/source/sites/publicodes/Actions.js
@@ -21,6 +21,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { setSimulationConfig } from 'Actions/actions'
 import Viande from './Viande'
 import Action from './Action'
+import ActionPlus from './ActionPlus'
 import { humanValueAndUnit } from './HumanWeight'
 import { encodeRuleName, decodeRuleName, splitName } from 'Engine/rules'
 
@@ -30,9 +31,13 @@ const gradient = tinygradient(['#0000ff', '#ff0000']),
 export default ({}) => {
 	return (
 		<Switch>
+			<Route path="/actions/plus/:encodedName+">
+				<ActionPlus />
+			</Route>
 			<Route path="/actions/:encodedName+">
 				<Action />
 			</Route>
+
 			<Route path="/actions">
 				<AnimatedDiv />
 			</Route>

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -83,7 +83,6 @@ class App extends Component {
 							{/* Lien de compatibilité, à retirer par exemple mi-juillet 2020*/}
 							<Route path="/fin/:score" component={Fin} />
 							<Route path="/fin" component={Fin} />
-							<Route path="/actions/:action+" component={Actions} />
 							<Route path="/actions" component={Actions} />
 							<Route path="/contribuer/:input?" component={Contribution} />
 							<Route path="/à-propos" component={About} />

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -13,7 +13,6 @@ import Simulateur from './Simulateur'
 import Fin from './Fin'
 import VersionBeta from './VersionBeta'
 import Actions from './Actions'
-import ActionPlus from './ActionPlus'
 import sitePaths from './sitePaths'
 import Logo from './Logo'
 import { StoreProvider } from './StoreContext'
@@ -84,7 +83,6 @@ class App extends Component {
 							{/* Lien de compatibilité, à retirer par exemple mi-juillet 2020*/}
 							<Route path="/fin/:score" component={Fin} />
 							<Route path="/fin" component={Fin} />
-							<Route path="/actions/plus/:action+" component={ActionPlus} />
 							<Route path="/actions/:action+" component={Actions} />
 							<Route path="/actions" component={Actions} />
 							<Route path="/contribuer/:input?" component={Contribution} />

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -13,6 +13,7 @@ import Simulateur from './Simulateur'
 import Fin from './Fin'
 import VersionBeta from './VersionBeta'
 import Actions from './Actions'
+import ActionPlus from './ActionPlus'
 import sitePaths from './sitePaths'
 import Logo from './Logo'
 import { StoreProvider } from './StoreContext'
@@ -83,6 +84,7 @@ class App extends Component {
 							{/* Lien de compatibilité, à retirer par exemple mi-juillet 2020*/}
 							<Route path="/fin/:score" component={Fin} />
 							<Route path="/fin" component={Fin} />
+							<Route path="/actions/plus/:action+" component={ActionPlus} />
 							<Route path="/actions/:action+" component={Actions} />
 							<Route path="/actions" component={Actions} />
 							<Route path="/contribuer/:input?" component={Contribution} />


### PR DESCRIPTION
Au clic sur `En savoir plus` sur un geste climat, on affiche une documentation complète écrite en markdown sur ecolab-data.

A tester ici https://deploy-preview-140--nosgestesclimat.netlify.app/actions/plus/transport/éco‑conduite?PR=772

Fixes #131
Reste à faire : 
- [x] publier les fiches sur ecolab-data [en cours, bugs à trouver]
- [x] n'afficher le bouton que si la doc existe
- [ ] (éventuellement) faire une page sympa qui liste toutes les fiches plus pour le SEO